### PR TITLE
Suppress warnings built with Moveit2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_parser test/srdf_parser.test)
 
   add_definitions(-DTEST_RESOURCE_LOCATION="${CMAKE_SOURCE_DIR}/test/resources")
-  execute_process(COMMAND bash -c "locale -a | grep -q ^nl_NL"
+  execute_process(COMMAND bash -c "locale -a | grep -q ^en_US"
     RESULT_VARIABLE TEST_LOCALE
     OUTPUT_QUIET ERROR_QUIET)
   if (TEST_LOCALE)

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -54,12 +54,12 @@ void srdf::Model::loadVirtualJoints(const urdf::ModelInterface& urdf_model, TiXm
     const char* type = vj_xml->Attribute("type");
     if (!jname)
     {
-      CONSOLE_BRIDGE_logError("Name of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Name of virtual joint is not specified", NULL);
       continue;
     }
     if (!child)
     {
-      CONSOLE_BRIDGE_logError("Child link of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Child link of virtual joint is not specified", NULL);
       continue;
     }
     if (!urdf_model.getLink(boost::trim_copy(std::string(child))))
@@ -69,12 +69,12 @@ void srdf::Model::loadVirtualJoints(const urdf::ModelInterface& urdf_model, TiXm
     }
     if (!parent)
     {
-      CONSOLE_BRIDGE_logError("Parent frame of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Parent frame of virtual joint is not specified", NULL);
       continue;
     }
     if (!type)
     {
-      CONSOLE_BRIDGE_logError("Type of virtual joint is not specified");
+      CONSOLE_BRIDGE_logError("Type of virtual joint is not specified", NULL);
       continue;
     }
     VirtualJoint vj;
@@ -106,7 +106,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface& urdf_model, TiXmlElemen
     const char* gname = group_xml->Attribute("name");
     if (!gname)
     {
-      CONSOLE_BRIDGE_logError("Group name not specified");
+      CONSOLE_BRIDGE_logError("Group name not specified", NULL);
       continue;
     }
     Group g;
@@ -120,7 +120,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface& urdf_model, TiXmlElemen
       const char* lname = link_xml->Attribute("name");
       if (!lname)
       {
-        CONSOLE_BRIDGE_logError("Link name not specified");
+        CONSOLE_BRIDGE_logError("Link name not specified", NULL);
         continue;
       }
       std::string lname_str = boost::trim_copy(std::string(lname));
@@ -139,7 +139,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface& urdf_model, TiXmlElemen
       const char* jname = joint_xml->Attribute("name");
       if (!jname)
       {
-        CONSOLE_BRIDGE_logError("Joint name not specified");
+        CONSOLE_BRIDGE_logError("Joint name not specified", NULL);
         continue;
       }
       std::string jname_str = boost::trim_copy(std::string(jname));
@@ -169,12 +169,12 @@ void srdf::Model::loadGroups(const urdf::ModelInterface& urdf_model, TiXmlElemen
       const char* tip = chain_xml->Attribute("tip_link");
       if (!base)
       {
-        CONSOLE_BRIDGE_logError("Base link name not specified for chain");
+        CONSOLE_BRIDGE_logError("Base link name not specified for chain", NULL);
         continue;
       }
       if (!tip)
       {
-        CONSOLE_BRIDGE_logError("Tip link name not specified for chain");
+        CONSOLE_BRIDGE_logError("Tip link name not specified for chain", NULL);
         continue;
       }
       std::string base_str = boost::trim_copy(std::string(base));
@@ -227,7 +227,7 @@ void srdf::Model::loadGroups(const urdf::ModelInterface& urdf_model, TiXmlElemen
       const char* sub = subg_xml->Attribute("name");
       if (!sub)
       {
-        CONSOLE_BRIDGE_logError("Group name not specified when included as subgroup");
+        CONSOLE_BRIDGE_logError("Group name not specified when included as subgroup", NULL);
         continue;
       }
       g.subgroups_.push_back(boost::trim_copy(std::string(sub)));
@@ -289,7 +289,7 @@ void srdf::Model::loadGroupStates(const urdf::ModelInterface& urdf_model, TiXmlE
     const char* gname = gstate_xml->Attribute("group");
     if (!sname)
     {
-      CONSOLE_BRIDGE_logError("Name of group state is not specified");
+      CONSOLE_BRIDGE_logError("Name of group state is not specified", NULL);
       continue;
     }
     if (!gname)
@@ -387,7 +387,7 @@ void srdf::Model::loadEndEffectors(const urdf::ModelInterface& urdf_model, TiXml
     const char* parent_group = eef_xml->Attribute("parent_group");
     if (!ename)
     {
-      CONSOLE_BRIDGE_logError("Name of end effector is not specified");
+      CONSOLE_BRIDGE_logError("Name of end effector is not specified", NULL);
       continue;
     }
     if (!gname)
@@ -443,7 +443,7 @@ void srdf::Model::loadLinkSphereApproximations(const urdf::ModelInterface& urdf_
     const char* link_name = cslink_xml->Attribute("link");
     if (!link_name)
     {
-      CONSOLE_BRIDGE_logError("Name of link is not specified in link_collision_spheres");
+      CONSOLE_BRIDGE_logError("Name of link is not specified in link_collision_spheres", NULL);
       continue;
     }
 
@@ -540,7 +540,7 @@ void srdf::Model::loadDisabledCollisions(const urdf::ModelInterface& urdf_model,
     const char* link2 = c_xml->Attribute("link2");
     if (!link1 || !link2)
     {
-      CONSOLE_BRIDGE_logError("A pair of links needs to be specified to disable collisions");
+      CONSOLE_BRIDGE_logError("A pair of links needs to be specified to disable collisions", NULL);
       continue;
     }
     DisabledCollision dc;
@@ -571,7 +571,7 @@ void srdf::Model::loadPassiveJoints(const urdf::ModelInterface& urdf_model, TiXm
     const char* name = c_xml->Attribute("name");
     if (!name)
     {
-      CONSOLE_BRIDGE_logError("No name specified for passive joint. Ignoring.");
+      CONSOLE_BRIDGE_logError("No name specified for passive joint. Ignoring.", NULL);
       continue;
     }
     PassiveJoint pj;
@@ -597,20 +597,20 @@ bool srdf::Model::initXml(const urdf::ModelInterface& urdf_model, TiXmlElement* 
   clear();
   if (!robot_xml || robot_xml->ValueStr() != "robot")
   {
-    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file");
+    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file", NULL);
     return false;
   }
 
   // get the robot name
   const char* name = robot_xml->Attribute("name");
   if (!name)
-    CONSOLE_BRIDGE_logError("No name given for the robot.");
+    CONSOLE_BRIDGE_logError("No name given for the robot.", NULL);
   else
   {
     name_ = std::string(name);
     boost::trim(name_);
     if (name_ != urdf_model.getName())
-      CONSOLE_BRIDGE_logError("Semantic description is not specified for the same robot as the URDF");
+      CONSOLE_BRIDGE_logError("Semantic description is not specified for the same robot as the URDF", NULL);
   }
 
   loadVirtualJoints(urdf_model, robot_xml);
@@ -629,7 +629,7 @@ bool srdf::Model::initXml(const urdf::ModelInterface& urdf_model, TiXmlDocument*
   TiXmlElement* robot_xml = xml ? xml->FirstChildElement("robot") : NULL;
   if (!robot_xml)
   {
-    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file");
+    CONSOLE_BRIDGE_logError("Could not find the 'robot' element in the xml file", NULL);
     return false;
   }
   return initXml(urdf_model, robot_xml);

--- a/test/srdf_parser_cpp.test
+++ b/test/srdf_parser_cpp.test
@@ -3,6 +3,6 @@
     <env name="LC_ALL" value="C" />
   </test>
   <test test-name="test_srdf_parser_cpp_locale" pkg="srdfdom" type="test_cpp">
-    <env name="LC_ALL" value="nl_NL.UTF-8" />
+    <env name="LC_ALL" value="en_US.utf8" />
   </test>
 </launch>

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -129,11 +129,17 @@ TEST(TestCpp, testComplex)
   for (std::size_t i = 0; i < s.getGroups().size(); ++i)
   {
     if (s.getGroups()[i].name_ == "left_arm" || s.getGroups()[i].name_ == "right_arm")
+    {
       EXPECT_TRUE(s.getGroups()[i].chains_.size() == 1);
+    }
     if (s.getGroups()[i].name_ == "arms")
+    {
       EXPECT_TRUE(s.getGroups()[i].subgroups_.size() == 2);
+    }
     if (s.getGroups()[i].name_ == "base")
+    {
       EXPECT_TRUE(s.getGroups()[i].joints_.size() == 1);
+    }
     if (s.getGroups()[i].name_ == "l_end_effector" || s.getGroups()[i].name_ == "r_end_effector")
     {
       EXPECT_TRUE(s.getGroups()[i].links_.size() == 1);


### PR DESCRIPTION
This PR intends to suppress the warnings shown up in the [CI result](https://travis-ci.org/ros-planning/moveit2/builds/606100580#L958) built with Moveit2.

1. **Fix locale missing warning**: Locale `nl_NL.UTF-8` is not normal on a fresh Ubuntu system. Change it to `en_US.UTF-8`, since it is recommended from [dashing install](https://index.ros.org/doc/ros2/Installation/Dashing/Linux-Install-Debians/#id2).

2. **Fix 'variadic macro' warning**: console_bridge defines logError macros as: 
```
#define CONSOLE_BRIDGE_logError(fmt, ...)  \
  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
```
If compile option `-Wpedantic` is used, any `CONSOLE_BRIDGE_logError` with only one argument, such as `CONSOLE_BRIDGE_logError("Name of virtual joint is not specified");` will trigger the warning: `warning: ISO C++11 requires at least one argument for the "..." in a variadic macro`. I took an easy work around by adding a `NULL` as another argument, like `CONSOLE_BRIDGE_logError("Name of virtual joint is not specified", NULL);`. Some more [info](https://en.wikipedia.org/wiki/Variadic_macro).

3. **Fix -Wdangling-else warning**: I suspect these three cases are false positive dangling-else warnings, since there is no else in the code. Added braces to avoid the warnings.